### PR TITLE
Fix typo in deployment.md

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -1,6 +1,6 @@
 # Deployment
 
-As this bundle leverages Assert Mapper, the resources are served using this great component.
+As this bundle leverages Asset Mapper, the resources are served using this great component.
 
 In the `dev` environment, the resources are automactilly handled and returned by your Symfony app.
 


### PR DESCRIPTION
Replace bad "Assert Mapper" bundle name by "Asset Mapper"